### PR TITLE
Refactor AiCenterApp to reuse logic in testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,21 @@ In order to use "aicenter", you need have a functioning install of python-devioc
 
 You can manage the instance daemon through procServ, by telneting to the configured port. 
 
+OpenCV
+======
+
+For best performance, a version of `python-opencv` compiled with support for CUDA and cuDNN along
+with a compatible GPU should be used.
+
+Testing
+=======
+
+The `test/inference.py` file can be used to test the inference / model performance without running
+a full IOC application.
+
+Create an environment with `requirements-test.txt` and install `aicenter` without dependencies:
+
+```
+pip install -r requirements-test.txt
+pip install . --no-deps
+```

--- a/aicenter/__init__.py
+++ b/aicenter/__init__.py
@@ -1,4 +1,111 @@
-from collections import namedtuple
+import os
+from collections import namedtuple, defaultdict
+
+import cv2
+import numpy
+
+from aicenter import utils
+
+try:
+    from devioc import log
+except ImportError:
+    import logging
+    logger = logging.getLogger('aicenter')
+else:
+    logger = log.get_module_logger('aicenter')
 
 # Result Type
 Result = namedtuple('Result', 'type x y w h score')
+
+CONF_THRESH, NMS_THRESH = 0.25, 0.25
+
+
+class AiCenter:
+    def __init__(self, model=None, server=None, camera=None):
+        self.key = f'{camera}:JPG'
+        self.server = server
+        self.video = None
+        self.model_path = model
+
+        # prepare neural network for detection
+        with open(os.path.join(model, 'yolov3.names'), 'r', encoding='utf-8') as fobj:
+            names = [line.strip() for line in fobj.readlines()]
+
+        self.darknet = {
+            'weights': os.path.join(model, 'yolov3.weights'),
+            'config': os.path.join(model, 'yolov3.cfg'),
+            'names': names,
+        }
+
+        self.net = cv2.dnn.readNetFromDarknet(self.darknet['config'], self.darknet['weights'])
+        self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
+        self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA_FP16)
+        self.layers = self.net.getLayerNames()
+        self.output_layers = self.net.getUnconnectedOutLayersNames()
+
+    def get_frame(self):
+        try:
+            data = self.video.get(self.key)
+            image = numpy.frombuffer(data, numpy.uint8)
+            frame = cv2.imdecode(image, cv2.IMREAD_COLOR)
+        except TypeError as err:
+            logger.error('Unable to grab frame')
+            return
+        else:
+            return frame
+
+    def process_results(self, width, height, outputs):
+        class_ids, confidences, bboxes = [], [], []
+        for output in outputs:
+            for detection in output:
+                scores = detection[5:]
+                class_id = numpy.argmax(scores)
+                confidence = scores[class_id]
+
+                if confidence > CONF_THRESH:
+                    cx, cy, w, h = (detection[0:4] * numpy.array([width, height, width, height])).astype(int)
+                    x = int(cx - w / 2)
+                    y = int(cy - h / 2)
+
+                    bboxes.append([x, y, int(w), int(h)])
+                    confidences.append(float(confidence))
+                    class_ids.append(int(class_id))
+
+        if bboxes:
+            results = defaultdict(list)
+            indices = cv2.dnn.NMSBoxes(bboxes, confidences, CONF_THRESH, NMS_THRESH).flatten()
+            nms_boxes = [(bboxes[i], confidences[i], class_ids[i]) for i in indices]
+            for bbox, score, class_id in nms_boxes:
+                x, y, w, h = bbox
+                label = self.darknet['names'][class_id]
+                logger.debug(f'{label} found at: {x} {y} [{w} {h}], prob={score}')
+                results[label].append(Result(label, x, y, w, h, score))
+            for label, llist in results.items():
+                results[label] = sorted(llist, key=lambda result: result.score, reverse=True)
+            return results
+
+    @staticmethod
+    def process_features(frame):
+        """
+        Process frame using traditional image processing techniques to detect loop
+        :param frame: Frame to process
+        :return: True if loop found
+        """
+        info = utils.find_loop(frame)
+        if 'loop-x' in info:
+            logger.debug(
+                f'Loop found at: {info["loop-x"]} {info["loop-y"]} [{info["loop-width"]} {info["loop-height"]}]'
+            )
+            return {'loop': Result('loop', info['loop-x'], info['loop-y'], info['loop-width'], info['loop-height'], 0.5)}
+
+    def process_frame(self, frame):
+        if frame is not None:
+            height, width = frame.shape[:2]
+            blob = cv2.dnn.blobFromImage(frame, 0.00392, (416, 416), swapRB=True, crop=False)
+            self.net.setInput(blob)
+            outputs = self.net.forward(self.output_layers)
+            results = self.process_results(width, height, outputs)
+            if not results:
+                # attempt regular image processing
+                results = self.process_features(frame)
+            return results

--- a/aicenter/__init__.py
+++ b/aicenter/__init__.py
@@ -96,7 +96,7 @@ class AiCenter:
             logger.debug(
                 f'Loop found at: {info["loop-x"]} {info["loop-y"]} [{info["loop-width"]} {info["loop-height"]}]'
             )
-            return {'loop': Result('loop', info['loop-x'], info['loop-y'], info['loop-width'], info['loop-height'], 0.5)}
+            return {'loop': [Result('loop', info['loop-x'], info['loop-y'], info['loop-width'], info['loop-height'], 0.5)]}
 
     def process_frame(self, frame):
         if frame is not None:

--- a/aicenter/__init__.py
+++ b/aicenter/__init__.py
@@ -1,0 +1,4 @@
+from collections import namedtuple
+
+# Result Type
+Result = namedtuple('Result', 'type x y w h score')

--- a/aicenter/ioc.py
+++ b/aicenter/ioc.py
@@ -1,21 +1,16 @@
-import os
 import threading
 import time
 import warnings
 
-import cv2
 import numpy
 import redis
 
 warnings.filterwarnings("ignore")
 
 from enum import IntEnum
-from collections import defaultdict
 
 from devioc import models, log
 import gepics
-
-from . import utils, Result
 
 logger = log.get_module_logger('aicenter')
 
@@ -44,32 +39,12 @@ class AiCenter(models.Model):
     objects_valid = models.Integer('objects:valid', default=0, desc="Valid objects")
 
 
-class AiCenterApp(object):
+class AiCenterApp(AiCenter):
     def __init__(self, device, model=None, server=None, camera=None):
+        super().__init__(model=model, server=server, camera=camera)
         logger.info(f'device={device!r}, model={model!r}, server={server!r}, camera={camera!r}')
         self.running = False
         self.ioc = AiCenter(device, callbacks=self)
-        self.key = f'{camera}:JPG'
-        self.server = server
-        self.video = None
-        self.model_path = model
-
-        # prepare neural network for detection
-        with open(os.path.join(model, 'yolov3.names'), 'r', encoding='utf-8') as fobj:
-            names = [line.strip() for line in fobj.readlines()]
-
-        self.darknet = {
-            'weights': os.path.join(model, 'yolov3.weights'),
-            'config': os.path.join(model, 'yolov3.cfg'),
-            'names': names,
-        }
-
-        self.net = cv2.dnn.readNetFromDarknet(self.darknet['config'], self.darknet['weights'])
-        self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
-        self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA_FP16)
-        self.layers = self.net.getLayerNames()
-        self.output_layers = self.net.getUnconnectedOutLayersNames()
-        # self.output_layers = [self.layers[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
 
         self.start_monitor()
 
@@ -78,109 +53,39 @@ class AiCenterApp(object):
         monitor_thread = threading.Thread(target=self.video_monitor, daemon=True)
         monitor_thread.start()
 
-    def get_frame(self):
-        try:
-            data = self.video.get(self.key)
-            image = numpy.frombuffer(data, numpy.uint8)
-            frame = cv2.imdecode(image, cv2.IMREAD_COLOR)
-        except TypeError as err:
-            logger.error('Unable to grab frame')
-            return
-        else:
-            return frame
-
-    def process_results(self, width, height, outputs):
-        class_ids, confidences, bboxes = [], [], []
-        for output in outputs:
-            for detection in output:
-                scores = detection[5:]
-                class_id = numpy.argmax(scores)
-                confidence = scores[class_id]
-
-                if confidence > CONF_THRESH:
-                    cx, cy, w, h = (detection[0:4] * numpy.array([width, height, width, height])).astype(int)
-                    x = int(cx - w / 2)
-                    y = int(cy - h / 2)
-
-                    bboxes.append([x, y, int(w), int(h)])
-                    confidences.append(float(confidence))
-                    class_ids.append(int(class_id))
-
-        if bboxes:
-            results = defaultdict(list)
-            indices = cv2.dnn.NMSBoxes(bboxes, confidences, CONF_THRESH, NMS_THRESH).flatten()
-            nms_boxes = [(bboxes[i], confidences[i], class_ids[i]) for i in indices]
-            for bbox, score, class_id in nms_boxes:
-                x, y, w, h = bbox
-                label = self.darknet['names'][class_id]
-                logger.debug(f'{label} found at: {x} {y} [{w} {h}], prob={score}')
-                results[label].append(Result(label, x, y, w, h, score))
-            for label, llist in results.items():
-                results[label] = sorted(llist, key=lambda result: result.score, reverse=True)
-            self.ioc.status.put(StatusType.VALID)
-            return results
-        else:
-            self.ioc.status.put(StatusType.INVALID)
-            self.ioc.score.put(0.0)
-
-    @staticmethod
-    def process_features(frame):
-        """
-        Process frame using traditional image processing techniques to detect loop
-        :param frame: Frame to process
-        :return: True if loop found
-        """
-        info = utils.find_loop(frame)
-        if 'loop-x' in info:
-            logger.debug(
-                f'Loop found at: {info["loop-x"]} {info["loop-y"]} [{info["loop-width"]} {info["loop-height"]}]'
-            )
-            return {'loop': Result('loop', info['loop-x'], info['loop-y'], info['loop-width'], info['loop-height'], 0.5)}
-
     def video_monitor(self):
         gepics.threads_init()
         self.running = True
         self.video = redis.Redis(host=self.server, port=6379, db=0)
         while self.running:
             frame = self.get_frame()
-            if frame is not None:
-                height, width = frame.shape[:2]
-                blob = cv2.dnn.blobFromImage(frame, 0.00392, (416, 416), swapRB=True, crop=False)
-                self.net.setInput(blob)
-                outputs = self.net.forward(self.output_layers)
-                results = self.process_results(width, height, outputs)
-                if not results:
-                    # attempt regular image processing
-                    results = self.process_features(frame)
+            results = self.process_frame(frame)
 
-                if results:
-                    if 'loop' in results:
-                        # Only return highest-scoring loop
-                        result = results['loop'][0]
-                        self.ioc.x.put(result.x)
-                        self.ioc.y.put(result.y)
-                        self.ioc.w.put(result.w)
-                        self.ioc.h.put(result.h)
-                        self.ioc.label.put(result.type)
-                        self.ioc.score.put(result.score)
-                        self.ioc.status.put(StatusType.VALID)
-                    xs = [], ys = [], scores = []
-                    for label, reslist in results.values():
-                        if label == 'loop':
-                            continue
-                        xs += [result.x + int(result.w / 2) for result in reslist]
-                        ys += [result.y + int(result.h / 2) for result in reslist]
-                        scores += [result.score for result in reslist]
-                    if xs:
-                        self.ioc.objects_x.put(numpy.array(xs))
-                        self.ioc.objects_y.put(numpy.array(ys))
-                        self.ioc.objects_score.put(numpy.array(scores))
-                        self.ioc.objects_valid.put(len(xs))
-                    else:
-                        self.ioc.objects_valid.put(0)
+            if results:
+                if 'loop' in results:
+                    # Only return highest-scoring loop
+                    result = results['loop'][0]
+                    self.ioc.x.put(result.x)
+                    self.ioc.y.put(result.y)
+                    self.ioc.w.put(result.w)
+                    self.ioc.h.put(result.h)
+                    self.ioc.label.put(result.type)
+                    self.ioc.score.put(result.score)
+                    self.ioc.status.put(StatusType.VALID)
+                xs = [], ys = [], scores = []
+                for label, reslist in results.values():
+                    if label == 'loop':
+                        continue
+                    xs += [result.x + int(result.w / 2) for result in reslist]
+                    ys += [result.y + int(result.h / 2) for result in reslist]
+                    scores += [result.score for result in reslist]
+                if xs:
+                    self.ioc.objects_x.put(numpy.array(xs))
+                    self.ioc.objects_y.put(numpy.array(ys))
+                    self.ioc.objects_score.put(numpy.array(scores))
+                    self.ioc.objects_valid.put(len(xs))
                 else:
-                    self.ioc.status.put(StatusType.INVALID)
-                    self.ioc.score.put(0.0)
+                    self.ioc.objects_valid.put(0)
             else:
                 self.ioc.status.put(StatusType.INVALID)
                 self.ioc.score.put(0.0)

--- a/aicenter/ioc.py
+++ b/aicenter/ioc.py
@@ -73,7 +73,7 @@ class AiCenterApp(AiCenter):
                     self.ioc.score.put(result.score)
                     self.ioc.status.put(StatusType.VALID)
                 xs = [], ys = [], scores = []
-                for label, reslist in results.values():
+                for label, reslist in results.items():
                     if label == 'loop':
                         continue
                     xs += [result.x + int(result.w / 2) for result in reslist]

--- a/aicenter/ioc.py
+++ b/aicenter/ioc.py
@@ -10,16 +10,14 @@ import redis
 warnings.filterwarnings("ignore")
 
 from enum import IntEnum
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 
 from devioc import models, log
 import gepics
 
-from . import utils
-logger = log.get_module_logger('aicenter')
+from . import utils, Result
 
-# Result Type
-Result = namedtuple('Result', 'type x y w h score')
+logger = log.get_module_logger('aicenter')
 
 CONF_THRESH, NMS_THRESH = 0.25, 0.25
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+opencv-python
+opencv-contrib-python
+numpy
+redis

--- a/test/inference.py
+++ b/test/inference.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 import argparse
+import glob
+import logging
+import os
+import time
 import warnings
 
 import cv2
@@ -8,6 +12,7 @@ import redis
 from aicenter import AiCenter
 
 warnings.filterwarnings("ignore")
+logger = logging.getLogger('aicenter')
 
 CONF_THRESH, NMS_THRESH = 0.25, 0.25
 
@@ -17,26 +22,60 @@ class AiCenterApp(AiCenter):
         super().__init__(**kwargs)
         print(f'model={self.model_path!r}, server={self.server!r}, camera={self.key!r}')
         self.running = False
+        if self.server:
+            self.video = redis.Redis(host=self.server, port=6379, db=0)
 
     def run(self, scale=0.5):
         self.running = True
-        self.video = redis.Redis(host=self.server, port=6379, db=0)
         while self.running:
             raw_frame = self.get_frame()
+            if raw_frame is None:
+                continue
             frame = cv2.resize(raw_frame, None, fx=scale, fy=scale, interpolation=cv2.INTER_AREA)
             results = self.process_frame(frame)
 
             if results is not None:
-                for res in results:
-                    cv2.rectangle(frame, (res.x, res.y), (res.x+res.w, res.y+res.h), (255, 0, 0), 1)
-                    cv2.putText(frame, f'{res.type}:{res.score:0.2f}', (res.x, res.y - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
-                                (255, 0, 0), 1, cv2.LINE_AA)
+                for label, reslist in results.items():
+                    for res in reslist:
+                        cv2.rectangle(frame, (res.x, res.y), (res.x+res.w, res.y+res.h), (255, 0, 0), 1)
+                        cv2.putText(frame, f'{res.type}:{res.score:0.2f}', (res.x, res.y - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
+                                    (255, 0, 0), 1, cv2.LINE_AA)
 
             cv2.imshow('Frame', frame)
 
             if cv2.waitKey(1) & 0xFF == ord('q'):
                 break
 
+
+class AiCenterImagesApp(AiCenterApp):
+    def __init__(self, **kwargs):
+        images_dir = kwargs.pop('images')
+        self.images = self.frame_generator(images_dir)
+        print(f"Simulating stream from {images_dir!r}")
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def frame_generator(images):
+        for filename in sorted(glob.glob(os.path.join(images, "*[.png,.jpg,.jpeg]"))):
+            t = time.perf_counter()
+            try:
+                image = cv2.imread(filename)
+            except TypeError as err:
+                logger.error('Unable to grab frame')
+                return
+            else:
+                yield image
+            delay = t + 0.1 - time.perf_counter()
+            if delay > 0:
+                time.sleep(delay)
+
+    def get_frame(self):
+        try:
+            frame = next(self.images)
+        except StopIteration:
+            self.running = False
+        else:
+            return frame
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Annotate a video stream using a pre-trained object detection model')
@@ -46,6 +85,10 @@ if __name__ == '__main__':
                         default="IOC1608-304.clsi.ca")
     parser.add_argument('--camera', type=str, help='Redis camera ID',
                         default="0030180F06E5")
+    parser.add_argument('--images', type=str, help='Path to directory of images (simulate stream)')
     args = parser.parse_args()
-    app = AiCenterApp(model=args.model, server=args.server, camera=args.camera)
+    if args.images:
+        app = AiCenterImagesApp(model=args.model, images=args.images)
+    else:
+        app = AiCenterApp(model=args.model, server=args.server, camera=args.camera)
     app.run()

--- a/test/inference.py
+++ b/test/inference.py
@@ -1,94 +1,22 @@
 #!/usr/bin/env python3
 
-import os
 import warnings
 
 import cv2
-import numpy
 import redis
 
-from aicenter import Result
-from aicenter.utils import find_loop
+from aicenter import AiCenter
 
 warnings.filterwarnings("ignore")
 
 CONF_THRESH, NMS_THRESH = 0.25, 0.25
 
-class AiCenterApp(object):
-    def __init__(self, model=None, server=None, camera=None):
-        print(f'model={model!r}, server={server!r}, camera={camera!r}')
+
+class AiCenterApp(AiCenter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        print(f'model={self.model_path!r}, server={self.server!r}, camera={self.key!r}')
         self.running = False
-        self.key = f'{camera}:JPG'
-        self.server = server
-        self.video = None
-        self.model_path = model
-
-        # prepare neural network for detection
-        with open(os.path.join(model, 'yolov3.names'), 'r', encoding='utf-8') as fobj:
-            names = [line.strip() for line in fobj.readlines()]
-
-        self.darknet = {
-            'weights': os.path.join(model, 'yolov3.weights'),
-            'config': os.path.join(model, 'yolov3.cfg'),
-            'names': names,
-        }
-
-        self.net = cv2.dnn.readNetFromDarknet(self.darknet['config'], self.darknet['weights'])
-        self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
-        self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA_FP16)
-        self.layers = self.net.getLayerNames()
-        self.output_layers = self.net.getUnconnectedOutLayersNames()
-
-    def get_frame(self):
-        try:
-            data = self.video.get(self.key)
-            image = numpy.frombuffer(data, numpy.uint8)
-            frame = cv2.imdecode(image, cv2.IMREAD_COLOR)
-        except TypeError as err:
-            print('Unable to grab frame')
-            return
-        else:
-            return frame
-
-    def process_results(self, width, height, outputs):
-        class_ids, confidences, bboxes = [], [], []
-        for output in outputs:
-            for detection in output:
-                scores = detection[5:]
-                class_id = numpy.argmax(scores)
-                confidence = scores[class_id]
-
-                if confidence > CONF_THRESH:
-                    cx, cy, w, h = (detection[0:4] * numpy.array([width, height, width, height])).astype(int)
-
-                    x = int(cx - w / 2)
-                    y = int(cy - h / 2)
-
-                    bboxes.append([x, y, int(w), int(h)])
-                    confidences.append(float(confidence))
-                    class_ids.append(int(class_id))
-
-        if bboxes:
-            indices = cv2.dnn.NMSBoxes(bboxes, confidences, CONF_THRESH, NMS_THRESH).flatten()
-            scores = [confidences[index] for index in indices]
-            index = indices[numpy.argmax(scores)]
-            x, y, w, h = bboxes[index]
-            score = confidences[index]
-            label = self.darknet['names'][class_ids[index]]
-            print(f'{label} found at: {x} {y} [{w} {h}], prob={score}')
-            return Result(label, x, y, w, h, score)
-
-    @staticmethod
-    def process_features(frame):
-        """
-        Process frame using traditional image processing techniques to detect loop
-        :param frame: Frame to process
-        :return: True if loop found
-        """
-        info = find_loop(frame)
-        if "loop-x" in info:
-            print(f'Loop found at: {info["loop-x"]} {info["loop-y"]} [{info["loop-width"]} {info["loop-height"]}]')
-            return Result('loop', info['loop-x'], info['loop-y'], info['loop-width'], info['loop-height'], 1.0)
 
     def run(self, scale=0.5):
         self.running = True
@@ -96,28 +24,18 @@ class AiCenterApp(object):
         while self.running:
             raw_frame = self.get_frame()
             frame = cv2.resize(raw_frame, None, fx=scale, fy=scale, interpolation=cv2.INTER_AREA)
-            if frame is not None:
-                height, width = frame.shape[:2]
-                blob = cv2.dnn.blobFromImage(frame, 0.00392, (416, 416), swapRB=True, crop=False)
-                self.net.setInput(blob)
-                outputs = self.net.forward(self.output_layers)
-                res = self.process_results(width, height, outputs)
-                if not res:
-                    res = self.process_features(frame)
+            results = self.process_frame(frame)
 
-                if res is not None:
+            if results is not None:
+                for res in results:
                     cv2.rectangle(frame, (res.x, res.y), (res.x+res.w, res.y+res.h), (255, 0, 0), 1)
                     cv2.putText(frame, f'{res.type}:{res.score:0.2f}', (res.x, res.y - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
                                 (255, 0, 0), 1, cv2.LINE_AA)
 
-                cv2.imshow('Frame', frame)
+            cv2.imshow('Frame', frame)
 
             if cv2.waitKey(1) & 0xFF == ord('q'):
                 break
-
-    def shutdown(self):
-        # needed for proper IOC shutdown
-        self.running = False
 
 
 if __name__ == '__main__':

--- a/test/inference.py
+++ b/test/inference.py
@@ -1,28 +1,18 @@
 #!/usr/bin/env python3
 
 import os
-import threading
-import time
 import warnings
 
 import cv2
 import numpy
 import redis
 
+from aicenter.ioc import Result
+from aicenter.utils import find_loop
+
 warnings.filterwarnings("ignore")
 
-from enum import Enum
-from collections import namedtuple
-
-# Result Type
-Result = namedtuple('Result', 'type x y w h score')
-
 CONF_THRESH, NMS_THRESH = 0.25, 0.25
-
-
-class StatusType(Enum):
-    VALID, INVALID = range(2)
-
 
 class AiCenterApp(object):
     def __init__(self, model=None, server=None, camera=None):
@@ -128,109 +118,6 @@ class AiCenterApp(object):
     def shutdown(self):
         # needed for proper IOC shutdown
         self.running = False
-
-
-def find_loop(orig, offset=10, scale=0.5, orientation='left'):
-    raw = cv2.flip(orig, 1) if orientation != 'left' else orig
-    y_max, x_max = orig.shape[:2]
-    frame = cv2.resize(raw, (0, 0), fx=scale, fy=scale)
-
-    clean = cv2.fastNlMeansDenoisingColored(frame, None, 10, 10, 11, 11)
-    gray = cv2.cvtColor(clean, cv2.COLOR_BGR2GRAY)
-    thresh = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 11, 3)
-    edges = cv2.bitwise_not(cv2.dilate(thresh, None, 10))
-    avg, stdev = cv2.meanStdDev(gray)
-
-    edges[:offset, :] = 0
-    edges[-offset:, :] = 0
-    edges[:, -offset:] = 0
-    height, width = edges.shape
-    tip_x, tip_y = width // 2, height // 2
-
-    info = {
-        'mean': avg,
-        'std': stdev,
-        'signal': avg / stdev,
-        'found': 0,                 # 0 = nothing found, 1 = tip found, 2 = ellipse fitted.
-        'center-x': tip_x / scale,
-        'center-y': tip_y / scale,
-        'score': 0.0,
-    }
-
-    if edges.max() > 10:
-        info['found'] = 1
-        prof = numpy.argwhere(edges.T > 128)
-        cols, indices = numpy.unique(prof[:, 0], return_index=True)
-        data = numpy.split(prof[:, 1], indices[1:])
-        profiles = numpy.zeros((len(cols), 5), int)
-        for i, arr in enumerate(data):
-            mini, maxi = arr.min(), arr.max()
-            profiles[i, :] = (cols[i], mini, maxi, maxi - mini, (maxi + mini) // 2)
-            cv2.line(edges, (cols[i], mini), (cols[i], maxi), (128, 0, 255), 1)
-
-        search_width = width / 8
-        idx = 3
-        valid = (
-            (numpy.abs(profiles[:, idx] - profiles[:, idx].mean()) < 2 * profiles[:, idx].std())
-            & (profiles[:, idx] < 0.8 * height)
-        )
-        if valid.sum() > 5:
-            profiles = profiles[valid]
-
-        tip_x = profiles[:, 0].max()
-        tip_y = profiles[profiles[:, 0].argmax(), 4]
-
-        info['x'] = tip_x / scale
-        info['y'] = tip_y / scale
-        valid = (profiles[:, 0] >= tip_x - search_width)
-
-        vertices = numpy.concatenate((
-            profiles[:, (0, 1)][valid],
-            profiles[:, (0, 2)][valid][::-1]
-        )).astype(int)
-        sizes = profiles[:, 3][valid]
-
-        if len(vertices) > 5:
-            center, size, angle = cv2.fitEllipse(vertices)
-            c_x, c_y = center
-            s_x, s_y = size
-            if abs(c_y - tip_y) > height // 2 or s_x >= width or s_y >= height:
-                center, size, angle = cv2.minAreaRect(vertices)
-            info['found'] = 2
-            info['ellipse'] = (
-                tuple([int(x / scale) for x in center]),
-                tuple([int(x / scale) for x in size]),
-                angle,
-            )
-
-            ellipse_x, ellipse_y = info['ellipse'][0]
-            ellipse_w, ellipse_h = max(info['ellipse'][1]), min(info['ellipse'][1])
-
-            info['loop-x'] = int(ellipse_x)
-            info['loop-y'] = int(ellipse_y)
-            info['loop-width'] = ellipse_w
-            info['loop-height'] = ellipse_h
-            info['loop-angle'] = angle
-
-            info['loop-start'] = ellipse_x + info['loop-width']/2
-            info['loop-end'] = ellipse_x - info['loop-width']/2
-            info['score'] = 100*(1 - abs(info['loop-start'] - info['x'])/info['loop-width'])
-
-        info['sizes'] = (sizes / scale).astype(int)
-        info['points'] = [(int(x / scale), int(y / scale)) for x, y in vertices]
-
-    else:
-        info['x'] = 0
-        info['y'] = info['center-x']
-
-    if orientation == 'right':
-        for k in ['loop-x', 'loop-start', 'loop-end', 'x']:
-            if k in info:
-                info[k] = x_max - info[k]
-        if 'points' in info:
-            info['points'] = [(x_max - x, y) for x, y in info['points']]
-
-    return info
 
 
 if __name__ == '__main__':

--- a/test/inference.py
+++ b/test/inference.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import argparse
 import warnings
 
 import cv2
@@ -39,5 +39,13 @@ class AiCenterApp(AiCenter):
 
 
 if __name__ == '__main__':
-    app = AiCenterApp(model="/cmcf_apps/ai-centering/model", server="IOC1608-304.clsi.ca", camera="0030180F06E5")
+    parser = argparse.ArgumentParser(description='Annotate a video stream using a pre-trained object detection model')
+    parser.add_argument('--model', type=str, help='Path to model directory',
+                        default="/cmcf_apps/ai-centering/model")
+    parser.add_argument('--server', type=str, help='Redis camera server address',
+                        default="IOC1608-304.clsi.ca")
+    parser.add_argument('--camera', type=str, help='Redis camera ID',
+                        default="0030180F06E5")
+    args = parser.parse_args()
+    app = AiCenterApp(model=args.model, server=args.server, camera=args.camera)
     app.run()

--- a/test/inference.py
+++ b/test/inference.py
@@ -7,7 +7,7 @@ import cv2
 import numpy
 import redis
 
-from aicenter.ioc import Result
+from aicenter import Result
 from aicenter.utils import find_loop
 
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
Move the core stream prediction code to `aicenter.AiCenter` and then re-use that for both the IOC and the `inference.py` implementations. This allows testing of the prediction logic without running a full devIOC/EPICS environment.